### PR TITLE
Ai feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 src/*.egg-info
 dist
+__pycache__

--- a/pylint.sh
+++ b/pylint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+declare -i RESULT=0
+export PYRIGHT_PYTHON_FORCE_VERSION=latest
+echo "Pyright ..."
+python -m pyright .
+RESULT+=$?
+echo "Ruff ..."
+python -m ruff check --exclude tests/ .
+RESULT+=$?
+echo "Mypy ..."
+python -m mypy --explicit-package-bases --warn-return-any --check-untyped-defs --exclude tests/ .
+RESULT+=$?
+
+echo "Result : $RESULT"
+exit $RESULT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=61.0", "aiohttp"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,5 @@
+{
+  "exclude": [
+    "tests"
+  ]
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = pydmart
 version = 2.2.0
 author = <Kefah Issa>
 author_email = kefah.issa@gmail.com 
-description = A client to connect to a Dmart isntance
+description = A client to connect to a Dmart instance
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/edraj/pydmart
@@ -17,6 +17,10 @@ license_files = LICENSE.txt
 package_dir =
     = src
 packages = find:
+python_requires = >=3.11
+install_requires =
+    aiohttp>=3.8.0
+    pydantic>=2.0.0
 
 [options.packages.find]
 where = src

--- a/src/pydmart/__init__.py
+++ b/src/pydmart/__init__.py
@@ -1,0 +1,71 @@
+"""pydmart - Async Python client for the Dmart API."""
+
+from .service import DmartService
+from .models import (
+    ApiResponse,
+    ApiResponseRecord,
+    ActionResponse,
+    ActionRequest,
+    ActionRequestRecord,
+    QueryRequest,
+    ResponseEntry,
+    ResponseRecord,
+    Error,
+    DmartException,
+    Payload,
+    Translation,
+    Permission,
+    MetaExtended,
+    AggregationType,
+    AggregationReducer,
+)
+from .enums import (
+    Status,
+    Language,
+    UserType,
+    QueryType,
+    SortType,
+    RequestType,
+    ResourceAttachmentType,
+    ResourceType,
+    ContentType,
+    ContentTypeMedia,
+)
+from .consts import SUBPATH, SHORTNAME, SPACENAME
+
+__all__ = [
+    # Service
+    "DmartService",
+    # Models
+    "ApiResponse",
+    "ApiResponseRecord",
+    "ActionResponse",
+    "ActionRequest",
+    "ActionRequestRecord",
+    "QueryRequest",
+    "ResponseEntry",
+    "ResponseRecord",
+    "Error",
+    "DmartException",
+    "Payload",
+    "Translation",
+    "Permission",
+    "MetaExtended",
+    "AggregationType",
+    "AggregationReducer",
+    # Enums
+    "Status",
+    "Language",
+    "UserType",
+    "QueryType",
+    "SortType",
+    "RequestType",
+    "ResourceAttachmentType",
+    "ResourceType",
+    "ContentType",
+    "ContentTypeMedia",
+    # Constants
+    "SUBPATH",
+    "SHORTNAME",
+    "SPACENAME",
+]

--- a/src/pydmart/models.py
+++ b/src/pydmart/models.py
@@ -116,8 +116,8 @@ class MetaExtended(BaseModel):
 
 class ResponseEntry(MetaExtended):
     uuid: str
-    shortname: str = None
-    subpath: str = None
+    shortname: Optional[str] = None
+    subpath: Optional[str] = None
     is_active: bool
     displayname: Optional[Translation] = None
     description: Optional[Translation] = None

--- a/src/pydmart/service.py
+++ b/src/pydmart/service.py
@@ -125,8 +125,7 @@ class DmartService:
         except DmartException:
             raise
         except aiohttp.ClientResponseError as e:
-            error = await e.response.json()
-            raise DmartException(status_code=e.status, error=Error(**error))
+            raise DmartException(status_code=e.status, error=Error(type="ClientResponseError", code=e.status, message=e.message, info=[]))
         except aiohttp.ClientError as e:
             raise DmartException(status_code=500, error=Error(type="ClientError", code=500, message=str(e), info=[]))
 
@@ -276,8 +275,7 @@ class DmartService:
         except DmartException:
             raise
         except aiohttp.ClientResponseError as e:
-            error = await e.response.json()
-            raise DmartException(status_code=e.status, error=Error(**error))
+            raise DmartException(status_code=e.status, error=Error(type="ClientResponseError", code=e.status, message=e.message, info=[]))
         except aiohttp.ClientError as e:
             raise DmartException(status_code=500, error=Error(type="ClientError", code=500, message=str(e), info=[]))
 

--- a/src/pydmart/service.py
+++ b/src/pydmart/service.py
@@ -2,10 +2,11 @@ import json
 import aiohttp
 from typing import Any, Dict, List, Optional
 from .models import (
-    ApiResponse, ActionResponse, ResponseEntry, QueryRequest, ActionRequest,
+    ApiResponse, ResponseEntry, QueryRequest, ActionRequest,
     DmartException, Error
 )
 from .enums import QueryType, ResourceType, ContentType
+
 
 class DmartService:
     """High-level async client for the Dmart HTTP API.
@@ -15,15 +16,19 @@ class DmartService:
     authentication token. Most methods return pydantic models that mirror the
     API responses.
 
+    Supports async context manager protocol for automatic session lifecycle::
+
+        async with DmartService("https://api.example.com") as service:
+            await service.login("user", "pass")
+            data = await service.get_spaces()
+
     Attributes:
         base_url: Base endpoint of the Dmart service, e.g. https://api.example.com
         auth_token: Bearer token assigned upon successful login.
         current_user_roles: Cached roles from the user profile, if fetched.
         current_user_permissions: Cached permissions from the user profile, if fetched.
     """
-    base_url = "http://localhost:8282"
-    current_user_roles = []
-    current_user_permissions = []
+
     def __init__(self, base_url: str):
         """Initialize the service.
 
@@ -32,6 +37,42 @@ class DmartService:
         """
         self.base_url: str = base_url
         self.auth_token: str = ""
+        self.current_user_roles: List[str] = []
+        self.current_user_permissions: List[Any] = []
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def __aenter__(self) -> "DmartService":
+        """Enter the async context manager; creates a reusable HTTP session."""
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit the async context manager; closes the HTTP session."""
+        await self.close()
+
+    async def connect(self) -> None:
+        """Create the underlying aiohttp session for connection pooling.
+
+        Call this once before making requests, or use the async context
+        manager instead. Safe to call multiple times.
+        """
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+
+    async def close(self) -> None:
+        """Close the underlying aiohttp session.
+
+        Always call this when done, or use the async context manager.
+        """
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Return the current session, creating one lazily if needed."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
 
     @property
     def json_headers(self) -> Dict[str, str]:
@@ -48,8 +89,7 @@ class DmartService:
             "Authorization": f"Bearer {self.auth_token}" if self.auth_token else "",
         }
 
-
-    async def _request(self, method: str, url: str, **kwargs) -> Any:
+    async def _request(self, method: str, url: str, **kwargs: Any) -> ApiResponse:
         """Low-level request wrapper that normalizes responses and errors.
 
         Args:
@@ -58,24 +98,32 @@ class DmartService:
             **kwargs: Passed through to aiohttp.ClientSession.request.
 
         Returns:
-            ApiResponse or parsed model when possible; raises DmartException otherwise.
+            ApiResponse parsed from the server response.
+
+        Raises:
+            DmartException: On HTTP errors or when the server returns a
+                failure status.
         """
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.request(method, url, **kwargs) as response:
-                    data = await response.json()
-                    try:
-                        if data['status'] == 'failed':
-                            raise DmartException(status_code=400, error=Error(**data['error']))
-                        return ApiResponse(**data)
-                    except Exception as e:
-                        err = data.get('error', {
-                            'type': 'request',
-                            'code': 500,
-                            'message': str(e)
-                        })
-                        error = Error(**err)
-                        raise DmartException(status_code=400, error=error)
+            session = await self._get_session()
+            async with session.request(method, url, **kwargs) as response:
+                data = await response.json()
+                try:
+                    if data['status'] == 'failed':
+                        raise DmartException(status_code=400, error=Error(**data['error']))
+                    return ApiResponse(**data)
+                except DmartException:
+                    raise
+                except Exception as e:
+                    err = data.get('error', {
+                        'type': 'request',
+                        'code': 500,
+                        'message': str(e)
+                    })
+                    error = Error(**err)
+                    raise DmartException(status_code=400, error=error)
+        except DmartException:
+            raise
         except aiohttp.ClientResponseError as e:
             error = await e.response.json()
             raise DmartException(status_code=e.status, error=Error(**error))
@@ -83,42 +131,60 @@ class DmartService:
             raise DmartException(status_code=500, error=Error(type="ClientError", code=500, message=str(e), info=[]))
 
     async def login(self, shortname: str, password: str) -> ApiResponse:
-        """Login with shortname and password; stores auth token on success."""
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.request("POST", f"{self.base_url}/user/login", json={"shortname": shortname, "password": password}) as response:
-                    data = await response.json()
-            if isinstance(data, dict):
-                if not "records" in data and len(data["records"]) == 0:
-                    raise DmartException(
-                        status_code=500,
-                        error=Error(type="ClientError", code=500, message="Invalid response", info=[data])
-                    )
-                record = data["records"][0]
-                if "attributes" in record:
-                    self.auth_token = record["attributes"].get("access_token", None)
-                return ApiResponse(**data)
-            else:
-                raise DmartException(status_code=500, error=Error(type="ClientError", code=500, message="Invalid response", info=[]))
-        except DmartException as e:
-            raise e
-        except aiohttp.ClientResponseError as e:
-            error = await e.response.json()
-            raise DmartException(status_code=e.status, error=Error(**error))
-        except aiohttp.ClientError as e:
-            raise DmartException(status_code=500, error=Error(type="ClientError", code=500, message=str(e), info=[]))
+        """Login with shortname and password; stores auth token on success.
+
+        Args:
+            shortname: User shortname.
+            password: User password.
+
+        Returns:
+            ApiResponse containing the login record with access_token.
+
+        Raises:
+            DmartException: On invalid credentials or malformed response.
+        """
+        data = await self._request(
+            "POST",
+            f"{self.base_url}/user/login",
+            json={"shortname": shortname, "password": password},
+        )
+        if not data.records or len(data.records) == 0:
+            raise DmartException(
+                status_code=500,
+                error=Error(type="ClientError", code=500, message="Invalid response: no records", info=[])
+            )
+        record = data.records[0]
+        if record.attributes:
+            self.auth_token = record.attributes.get("access_token", "")
+        return data
 
     async def login_by(self, credentials: Dict[str, Any], password: str) -> ApiResponse:
-        """Login with arbitrary credentials dict plus password; stores auth token."""
-        data = await self._request("POST", f"{self.base_url}/user/login", json={**credentials, "password": password})
-        self.auth_token = data["records"][0]["attributes"]["access_token"]
+        """Login with arbitrary credentials dict plus password; stores auth token.
+
+        Args:
+            credentials: Dict with authentication fields (e.g. email, msisdn).
+            password: User password.
+
+        Returns:
+            ApiResponse containing the login record with access_token.
+
+        Raises:
+            DmartException: On invalid credentials or malformed response.
+        """
+        data = await self._request(
+            "POST",
+            f"{self.base_url}/user/login",
+            json={**credentials, "password": password},
+        )
+        if data.records:
+            self.auth_token = data.records[0].attributes.get("access_token", "")
         return data
 
     async def logout(self) -> ApiResponse:
         """Invalidate current token server-side (if any)."""
         return await self._request("POST", f"{self.base_url}/user/logout", headers=self.headers)
 
-    async def create_user(self, request: Dict[str, Any]) -> ActionResponse:
+    async def create_user(self, request: Dict[str, Any]) -> ApiResponse:
         """Create a new user.
 
         Args:
@@ -126,7 +192,7 @@ class DmartService:
         """
         return await self._request("POST", f"{self.base_url}/user/create", json=request, headers=self.json_headers)
 
-    async def update_user(self, request: Dict[str, Any]) -> ActionResponse:
+    async def update_user(self, request: Dict[str, Any]) -> ApiResponse:
         """Update current user profile attributes.
 
         Args:
@@ -134,16 +200,16 @@ class DmartService:
         """
         return await self._request("POST", f"{self.base_url}/user/profile", json=request, headers=self.json_headers)
 
-    async def check_existing(self, prop: str, value: str) -> ResponseEntry:
+    async def check_existing(self, prop: str, value: str) -> ApiResponse:
         """Check whether a user property already exists (e.g., email or shortname)."""
         return await self._request("GET", f"{self.base_url}/user/check-existing?{prop}={value}", headers=self.headers)
 
     async def get_profile(self) -> ApiResponse:
         """Fetch current user profile and cache permissions/roles on success."""
         data = await self._request("GET", f"{self.base_url}/user/profile", headers=self.headers)
-        if data.status == "success":
-            self.current_user_permissions = data.records[0].attributes.get("permissions")
-            self.current_user_roles = data.records[0].attributes.get("roles")
+        if data.status == "success" and data.records:
+            self.current_user_permissions = data.records[0].attributes.get("permissions", [])
+            self.current_user_roles = data.records[0].attributes.get("roles", [])
         return data
 
     async def query(self, query: QueryRequest, scope: str = "managed") -> ApiResponse:
@@ -159,11 +225,11 @@ class DmartService:
         """Export a query as CSV data (server-side generation)."""
         return await self._request("POST", f"{self.base_url}/managed/csv", json=query.model_dump(), headers=self.json_headers)
 
-    # async def space(self, action: ActionRequest) -> ActionResponse:
-    #     """Perform a space-level management action."""
-    #     return await self._request("POST", f"{self.base_url}/managed/space", json=action.model_dump(), headers=self.json_headers)
+    async def space(self, action: ActionRequest) -> ApiResponse:
+        """Perform a space-level management action."""
+        return await self._request("POST", f"{self.base_url}/managed/space", json=action.model_dump(), headers=self.json_headers)
 
-    async def request(self, action: ActionRequest) -> ActionResponse:
+    async def request(self, action: ActionRequest) -> ApiResponse:
         """Perform a generic managed request (create/update/etc.)."""
         return await self._request("POST", f"{self.base_url}/managed/request", json=action.model_dump(), headers=self.json_headers)
 
@@ -189,15 +255,26 @@ class DmartService:
             retrieve_attachments: Whether to include attachments.
             validate_schema: Validate payload against its schema on server.
             scope: API scope.
+
+        Returns:
+            ResponseEntry with the full resource data.
         """
-        url = f"{scope}/entry/{resource_type}/{space_name}/{subpath}/{shortname}?retrieve_json_payload={retrieve_json_payload}&retrieve_attachments={retrieve_attachments}&validate_schema={validate_schema}"
+        url = (
+            f"{self.base_url}/{scope}/entry/{resource_type}/{space_name}"
+            f"/{subpath}/{shortname}"
+            f"?retrieve_json_payload={retrieve_json_payload}"
+            f"&retrieve_attachments={retrieve_attachments}"
+            f"&validate_schema={validate_schema}"
+        )
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.request("GET", f"{self.base_url}/{url}", headers=self.headers) as response:
-                    data = await response.json()
-                    if data.get('status') == 'failed':
-                        raise DmartException(status_code=400, error=Error(**data['error']))
-                    return ResponseEntry(**data)
+            session = await self._get_session()
+            async with session.request("GET", url, headers=self.headers) as response:
+                data = await response.json()
+                if data.get('status') == 'failed':
+                    raise DmartException(status_code=400, error=Error(**data['error']))
+                return ResponseEntry(**data)
+        except DmartException:
+            raise
         except aiohttp.ClientResponseError as e:
             error = await e.response.json()
             raise DmartException(status_code=e.status, error=Error(**error))
@@ -216,7 +293,7 @@ class DmartService:
         scope: str = "managed"
     ) -> ApiResponse:
         """Upload a file together with a JSON payload as a single request."""
-        request_record_body = {
+        request_record_body: Dict[str, Any] = {
             "resource_type": resource_type,
             "subpath": subpath,
             "shortname": shortname,
@@ -244,7 +321,7 @@ class DmartService:
         query_string: str = "SELECT * FROM file",
         filter_data_assets: Optional[List[str]] = None,
         branch_name: Optional[str] = None
-    ) -> Dict[str, Any]:
+    ) -> ApiResponse:
         """Execute a query against a data asset (CSV/Parquet/JSONL/etc.)."""
         return await self._request("POST", f"{self.base_url}/managed/data-asset", json={
             "space_name": space_name,
@@ -300,7 +377,7 @@ class DmartService:
         """Build a direct URL to download an attachment payload."""
         return f"{self.base_url}/{scope}/payload/{resource_type}/{space_name}/{subpath}/{parent_shortname}/{shortname}{ext or ''}"
 
-    async def get_space_health(self, space_name: str) -> Dict[str, Any]:
+    async def get_space_health(self, space_name: str) -> ApiResponse:
         """Get health information for a space."""
         return await self._request("GET", f"{self.base_url}/managed/health/{space_name}", headers=self.headers)
 
@@ -313,7 +390,7 @@ class DmartService:
         schema_shortname: str = "",
         ext: str = ".json",
         scope: str = "managed"
-    ) -> Dict[str, Any]:
+    ) -> ApiResponse:
         """Fetch raw payload for a resource.
 
         Args:
@@ -325,7 +402,11 @@ class DmartService:
             ext: Extension to fetch (default .json).
             scope: API scope.
         """
-        return await self._request("GET", f"{self.base_url}/{scope}/payload/{resource_type}/{space_name}/{subpath}/{shortname}{schema_shortname}{ext}", headers=self.headers)
+        return await self._request(
+            "GET",
+            f"{self.base_url}/{scope}/payload/{resource_type}/{space_name}/{subpath}/{shortname}{schema_shortname}{ext}",
+            headers=self.headers,
+        )
 
     async def progress_ticket(
         self,
@@ -335,15 +416,20 @@ class DmartService:
         action: str,
         resolution: Optional[str] = None,
         comment: Optional[str] = None
-    ) -> Dict[str, Any]:
+    ) -> ApiResponse:
         """Move a ticket through its workflow with optional resolution/comment."""
-        payload = {}
+        payload: Dict[str, str] = {}
         if resolution:
             payload["resolution"] = resolution
         if comment:
             payload["comment"] = comment
 
-        return await self._request("PUT", f"{self.base_url}/managed/progress-ticket/{space_name}/{subpath}/{shortname}/{action}", json=payload, headers=self.json_headers)
+        return await self._request(
+            "PUT",
+            f"{self.base_url}/managed/progress-ticket/{space_name}/{subpath}/{shortname}/{action}",
+            json=payload,
+            headers=self.json_headers,
+        )
 
     async def submit(
         self,
@@ -353,7 +439,7 @@ class DmartService:
         record: Dict[str, Any],
         resource_type: Optional[ResourceType] = None,
         workflow_shortname: Optional[str] = None
-    ) -> Dict[str, Any]:
+    ) -> ApiResponse:
         """Public submit of a record to a space/schema, optionally via workflow."""
         url = f"{self.base_url}/public/submit/{space_name}"
         if resource_type:
@@ -366,13 +452,13 @@ class DmartService:
 
     async def otp_request(self, msisdn: Optional[str] = None, email: Optional[str] = None, accept_language: Optional[str] = None) -> ApiResponse:
         """Request an OTP for signup/verification via msisdn or email."""
-        payload = {}
+        payload: Dict[str, str] = {}
         if msisdn:
             payload["msisdn"] = msisdn
         if email:
             payload["email"] = email
 
-        headers = self.json_headers
+        headers = {**self.json_headers}
         if accept_language:
             headers["Accept-Language"] = accept_language
 
@@ -380,13 +466,13 @@ class DmartService:
 
     async def otp_request_login(self, msisdn: Optional[str] = None, email: Optional[str] = None, accept_language: Optional[str] = None) -> ApiResponse:
         """Request an OTP intended for login flows."""
-        payload = {}
+        payload: Dict[str, str] = {}
         if msisdn:
             payload["msisdn"] = msisdn
         if email:
             payload["email"] = email
 
-        headers = self.json_headers
+        headers = {**self.json_headers}
         if accept_language:
             headers["Accept-Language"] = accept_language
 
@@ -394,7 +480,7 @@ class DmartService:
 
     async def password_reset_request(self, msisdn: Optional[str] = None, shortname: Optional[str] = None, email: Optional[str] = None) -> ApiResponse:
         """Request a password reset token via msisdn, shortname, or email."""
-        payload = {}
+        payload: Dict[str, str] = {}
         if msisdn:
             payload["msisdn"] = msisdn
         if shortname:
@@ -406,9 +492,7 @@ class DmartService:
 
     async def confirm_otp(self, otp: str, msisdn: Optional[str] = None, email: Optional[str] = None) -> ApiResponse:
         """Confirm an OTP code sent to msisdn or email."""
-        payload = {
-            "otp": otp
-        }
+        payload: Dict[str, str] = {"otp": otp}
         if msisdn:
             payload["msisdn"] = msisdn
         if email:
@@ -424,19 +508,18 @@ class DmartService:
         """Validate password strength/policy server-side."""
         return await self._request("POST", f"{self.base_url}/user/validate_password", json={"password": password}, headers=self.json_headers)
 
-    async def get_manifest(self) -> Dict[str, Any]:
+    async def get_manifest(self) -> ApiResponse:
         """Retrieve server manifest information.
 
         Returns:
-            Dict containing version, build info and other manifest details.
+            ApiResponse containing version, build info and other manifest details.
         """
         return await self._request("GET", f"{self.base_url}/info/manifest", headers=self.headers)
 
+    async def get_settings(self) -> ApiResponse:
+        """Retrieve dmart settings and configurations.
 
-async def get_settings(self) -> Dict[str, Any]:
-    """Retrieve dmart settings and configurations.
-
-    Returns:
-        Dict containing various dmart settings and configurations.
-    """
-    return await self._request("GET", f"{self.base_url}/info/settings", headers=self.headers)
+        Returns:
+            ApiResponse containing various dmart settings and configurations.
+        """
+        return await self._request("GET", f"{self.base_url}/info/settings", headers=self.headers)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared fixtures for pydmart tests."""
+
+import sys
+import os
+import pytest
+
+# Ensure the src package and tests helpers are importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import BASE_URL  # noqa: E402
+
+
+@pytest.fixture
+def base_url() -> str:
+    return BASE_URL
+
+
+@pytest.fixture
+def service():
+    """Create a DmartService instance (not connected)."""
+    from pydmart.service import DmartService
+    return DmartService(BASE_URL)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,58 @@
+"""Shared test helpers for pydmart tests."""
+
+BASE_URL = "http://dmart.test:8282"
+
+
+def make_success_response(records=None):
+    """Helper to build a minimal successful API JSON response."""
+    return {
+        "status": "success",
+        "records": records or [],
+    }
+
+
+def make_failed_response(error_type="request", code=400, message="bad request"):
+    """Helper to build a minimal failed API JSON response."""
+    return {
+        "status": "failed",
+        "error": {
+            "type": error_type,
+            "code": code,
+            "message": message,
+            "info": [],
+        },
+    }
+
+
+def make_login_response(access_token="tok_abc123"):
+    """Helper to build a login success response."""
+    return make_success_response(records=[{
+        "resource_type": "user",
+        "shortname": "testuser",
+        "subpath": "/",
+        "attributes": {"access_token": access_token},
+    }])
+
+
+def make_profile_response(roles=None, permissions=None):
+    """Helper to build a profile success response."""
+    return make_success_response(records=[{
+        "resource_type": "user",
+        "shortname": "testuser",
+        "subpath": "/",
+        "attributes": {
+            "roles": roles or ["admin"],
+            "permissions": permissions or ["read", "write"],
+        },
+    }])
+
+
+def make_entry_response():
+    """Helper to build a ResponseEntry-compatible JSON dict."""
+    return {
+        "uuid": "abc-123",
+        "shortname": "myentry",
+        "subpath": "/content",
+        "is_active": True,
+        "tags": ["tag1", "tag2"],
+    }

--- a/tests/test_consts.py
+++ b/tests/test_consts.py
@@ -1,0 +1,87 @@
+"""Tests for pydmart.consts regex constants."""
+
+import re
+import pytest
+from pydmart.consts import SUBPATH, SHORTNAME, SPACENAME
+
+
+class TestSubpath:
+    """Validate the SUBPATH regex pattern."""
+
+    @pytest.mark.parametrize("value", [
+        "a",
+        "hello",
+        "hello/world",
+        "path_with_underscores",
+        "CamelCase",
+        "abc123",
+        "a" * 128,
+        # Arabic characters
+        "\u0627\u0628\u062a",
+        # Mixed
+        "docs/\u0627\u0628\u062a/page",
+    ])
+    def test_valid_subpaths(self, value: str):
+        assert re.match(SUBPATH, value), f"Expected '{value}' to match SUBPATH"
+
+    @pytest.mark.parametrize("value", [
+        "",                # empty
+        "a" * 129,         # too long
+        "has spaces",
+        "special!char",
+        "dot.path",
+        "dash-path",
+    ])
+    def test_invalid_subpaths(self, value: str):
+        assert not re.match(SUBPATH, value), f"Expected '{value}' NOT to match SUBPATH"
+
+
+class TestShortname:
+    """Validate the SHORTNAME regex pattern."""
+
+    @pytest.mark.parametrize("value", [
+        "a",
+        "hello",
+        "user_name",
+        "CamelCase",
+        "abc123",
+        "a" * 64,
+        "\u0627\u0628\u062a",
+    ])
+    def test_valid_shortnames(self, value: str):
+        assert re.match(SHORTNAME, value), f"Expected '{value}' to match SHORTNAME"
+
+    @pytest.mark.parametrize("value", [
+        "",
+        "a" * 65,
+        "has spaces",
+        "has/slash",
+        "has-dash",
+        "dot.name",
+    ])
+    def test_invalid_shortnames(self, value: str):
+        assert not re.match(SHORTNAME, value), f"Expected '{value}' NOT to match SHORTNAME"
+
+
+class TestSpacename:
+    """Validate the SPACENAME regex pattern."""
+
+    @pytest.mark.parametrize("value", [
+        "a",
+        "myspace",
+        "space_1",
+        "a" * 32,
+        "\u0627\u0628\u062a",
+    ])
+    def test_valid_spacenames(self, value: str):
+        assert re.match(SPACENAME, value), f"Expected '{value}' to match SPACENAME"
+
+    @pytest.mark.parametrize("value", [
+        "",
+        "a" * 33,
+        "has spaces",
+        "has/slash",
+        "has-dash",
+    ])
+    def test_invalid_spacenames(self, value: str):
+        assert not re.match(SPACENAME, value), f"Expected '{value}' NOT to match SPACENAME"

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,148 @@
+"""Tests for pydmart.enums."""
+
+import pytest
+from pydmart.enums import (
+    Status,
+    Language,
+    UserType,
+    QueryType,
+    SortType,
+    RequestType,
+    ResourceAttachmentType,
+    ResourceType,
+    ContentType,
+    ContentTypeMedia,
+)
+
+
+class TestStatus:
+    def test_values(self):
+        assert Status.success == "success"
+        assert Status.failed == "failed"
+
+    def test_membership(self):
+        assert len(Status) == 2
+
+    def test_is_str(self):
+        assert isinstance(Status.success, str)
+
+
+class TestLanguage:
+    def test_values(self):
+        assert Language.arabic == "arabic"
+        assert Language.english == "english"
+        assert Language.kurdish == "kurdish"
+        assert Language.french == "french"
+        assert Language.turkish == "turkish"
+
+    def test_count(self):
+        assert len(Language) == 5
+
+
+class TestUserType:
+    def test_values(self):
+        assert UserType.web == "web"
+        assert UserType.mobile == "mobile"
+        assert UserType.bot == "bot"
+
+    def test_count(self):
+        assert len(UserType) == 3
+
+
+class TestQueryType:
+    EXPECTED = [
+        "aggregation", "search", "subpath", "events", "history",
+        "tags", "spaces", "counters", "reports", "attachments",
+        "attachments_aggregation",
+    ]
+
+    def test_all_values_present(self):
+        values = [e.value for e in QueryType]
+        assert sorted(values) == sorted(self.EXPECTED)
+
+    def test_count(self):
+        assert len(QueryType) == 11
+
+    def test_str_usage(self):
+        assert f"type={QueryType.search}" == "type=search"
+
+
+class TestSortType:
+    def test_values(self):
+        assert SortType.ascending == "ascending"
+        assert SortType.descending == "descending"
+
+    def test_count(self):
+        assert len(SortType) == 2
+
+
+class TestRequestType:
+    EXPECTED = ["create", "update", "progress_ticket", "delete", "move", "update_acl", "assign"]
+
+    def test_all_values_present(self):
+        values = [e.value for e in RequestType]
+        assert sorted(values) == sorted(self.EXPECTED)
+
+    def test_count(self):
+        assert len(RequestType) == 7
+
+
+class TestResourceAttachmentType:
+    EXPECTED = ["json", "comment", "media", "relationship", "alteration", "csv", "parquet", "jsonl", "sqlite"]
+
+    def test_all_values_present(self):
+        values = [e.value for e in ResourceAttachmentType]
+        assert sorted(values) == sorted(self.EXPECTED)
+
+    def test_count(self):
+        assert len(ResourceAttachmentType) == 9
+
+
+class TestResourceType:
+    def test_count(self):
+        assert len(ResourceType) == 26
+
+    @pytest.mark.parametrize("name,value", [
+        ("user", "user"),
+        ("group", "group"),
+        ("folder", "folder"),
+        ("schema", "schema"),
+        ("content", "content"),
+        ("ticket", "ticket"),
+        ("space", "space"),
+        ("post", "post"),
+        ("notification", "notification"),
+    ])
+    def test_selected_values(self, name: str, value: str):
+        assert ResourceType[name] == value
+
+
+class TestContentType:
+    EXPECTED = [
+        "text", "html", "markdown", "json", "image", "python",
+        "pdf", "audio", "video", "jsonl", "csv", "sqlite", "parquet",
+    ]
+
+    def test_all_values_present(self):
+        values = [e.value for e in ContentType]
+        assert sorted(values) == sorted(self.EXPECTED)
+
+    def test_count(self):
+        assert len(ContentType) == 13
+
+
+class TestContentTypeMedia:
+    EXPECTED = ["text", "html", "markdown", "image", "python", "pdf", "audio", "video"]
+
+    def test_all_values_present(self):
+        values = [e.value for e in ContentTypeMedia]
+        assert sorted(values) == sorted(self.EXPECTED)
+
+    def test_count(self):
+        assert len(ContentTypeMedia) == 8
+
+    def test_subset_of_content_type(self):
+        """All ContentTypeMedia values should also appear in ContentType."""
+        ct_values = {e.value for e in ContentType}
+        for media in ContentTypeMedia:
+            assert media.value in ct_values

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,111 @@
+"""Tests for pydmart package-level exports."""
+
+import pydmart
+
+
+class TestPublicExports:
+    """Every symbol in __all__ must be importable from the top-level package."""
+
+    def test_all_defined(self):
+        assert hasattr(pydmart, "__all__")
+        assert len(pydmart.__all__) > 0
+
+    def test_all_symbols_importable(self):
+        for name in pydmart.__all__:
+            obj = getattr(pydmart, name, None)
+            assert obj is not None, f"pydmart.{name} is not importable"
+
+    # -- Service --
+    def test_dmart_service(self):
+        assert pydmart.DmartService is not None
+
+    # -- Models --
+    def test_api_response(self):
+        assert pydmart.ApiResponse is not None
+
+    def test_api_response_record(self):
+        assert pydmart.ApiResponseRecord is not None
+
+    def test_action_response(self):
+        assert pydmart.ActionResponse is not None
+
+    def test_action_request(self):
+        assert pydmart.ActionRequest is not None
+
+    def test_action_request_record(self):
+        assert pydmart.ActionRequestRecord is not None
+
+    def test_query_request(self):
+        assert pydmart.QueryRequest is not None
+
+    def test_response_entry(self):
+        assert pydmart.ResponseEntry is not None
+
+    def test_response_record(self):
+        assert pydmart.ResponseRecord is not None
+
+    def test_error(self):
+        assert pydmart.Error is not None
+
+    def test_dmart_exception(self):
+        assert pydmart.DmartException is not None
+
+    def test_payload(self):
+        assert pydmart.Payload is not None
+
+    def test_translation(self):
+        assert pydmart.Translation is not None
+
+    def test_permission(self):
+        assert pydmart.Permission is not None
+
+    def test_meta_extended(self):
+        assert pydmart.MetaExtended is not None
+
+    def test_aggregation_type(self):
+        assert pydmart.AggregationType is not None
+
+    def test_aggregation_reducer(self):
+        assert pydmart.AggregationReducer is not None
+
+    # -- Enums --
+    def test_status(self):
+        assert pydmart.Status.success == "success"
+
+    def test_language(self):
+        assert pydmart.Language.english == "english"
+
+    def test_user_type(self):
+        assert pydmart.UserType.web == "web"
+
+    def test_query_type(self):
+        assert pydmart.QueryType.search == "search"
+
+    def test_sort_type(self):
+        assert pydmart.SortType.ascending == "ascending"
+
+    def test_request_type(self):
+        assert pydmart.RequestType.create == "create"
+
+    def test_resource_attachment_type(self):
+        assert pydmart.ResourceAttachmentType.json == "json"
+
+    def test_resource_type(self):
+        assert pydmart.ResourceType.content == "content"
+
+    def test_content_type(self):
+        assert pydmart.ContentType.json == "json"
+
+    def test_content_type_media(self):
+        assert pydmart.ContentTypeMedia.image == "image"
+
+    # -- Constants --
+    def test_subpath(self):
+        assert isinstance(pydmart.SUBPATH, str)
+        assert pydmart.SUBPATH.startswith("^")
+
+    def test_shortname(self):
+        assert isinstance(pydmart.SHORTNAME, str)
+
+    def test_spacename(self):
+        assert isinstance(pydmart.SPACENAME, str)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,413 @@
+"""Tests for pydmart.models."""
+
+import pytest
+from pydantic import ValidationError
+from pydmart.models import (
+    Error,
+    DmartException,
+    ApiResponseRecord,
+    ApiResponse,
+    Translation,
+    LoginResponseRecord,
+    Permission,
+    ProfileResponseRecord,
+    AggregationReducer,
+    AggregationType,
+    QueryRequest,
+    Payload,
+    MetaExtended,
+    ResponseEntry,
+    ResponseRecord,
+    ActionResponse,
+    ActionRequestRecord,
+    ActionRequest,
+)
+from pydmart.enums import (
+    Status,
+    QueryType,
+    SortType,
+    ResourceType,
+    RequestType,
+    ContentType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Error
+# ---------------------------------------------------------------------------
+class TestError:
+    def test_basic(self):
+        err = Error(type="auth", code=401, message="unauthorized")
+        assert err.type == "auth"
+        assert err.code == 401
+        assert err.message == "unauthorized"
+        assert err.info is None
+
+    def test_with_info(self):
+        err = Error(type="validation", code=422, message="bad", info=[{"field": "name"}])
+        assert err.info == [{"field": "name"}]
+
+    def test_missing_required_field(self):
+        with pytest.raises(ValidationError):
+            Error(type="x", code=1)  # missing message
+
+
+# ---------------------------------------------------------------------------
+# DmartException
+# ---------------------------------------------------------------------------
+class TestDmartException:
+    def test_is_exception(self):
+        err = Error(type="x", code=1, message="m")
+        exc = DmartException(status_code=400, error=err)
+        assert isinstance(exc, Exception)
+        assert exc.status_code == 400
+        assert exc.error is err
+
+    def test_raise_and_catch(self):
+        err = Error(type="x", code=1, message="m")
+        with pytest.raises(DmartException) as exc_info:
+            raise DmartException(status_code=500, error=err)
+        assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# ApiResponseRecord
+# ---------------------------------------------------------------------------
+class TestApiResponseRecord:
+    def test_basic(self):
+        rec = ApiResponseRecord(
+            resource_type="content",
+            shortname="doc1",
+            subpath="/docs",
+            attributes={"title": "Hello"},
+        )
+        assert rec.resource_type == "content"
+        assert rec.shortname == "doc1"
+        assert rec.attachments is None
+
+    def test_with_attachments(self):
+        rec = ApiResponseRecord(
+            resource_type="content",
+            shortname="doc1",
+            subpath="/",
+            attributes={},
+            attachments={"media": []},
+        )
+        assert rec.attachments == {"media": []}
+
+
+# ---------------------------------------------------------------------------
+# ApiResponse
+# ---------------------------------------------------------------------------
+class TestApiResponse:
+    def test_success_empty(self):
+        resp = ApiResponse(status=Status.success)
+        assert resp.status == Status.success
+        assert resp.records == []
+        assert resp.error is None
+
+    def test_success_with_records(self):
+        resp = ApiResponse(
+            status=Status.success,
+            records=[{
+                "resource_type": "user",
+                "shortname": "admin",
+                "subpath": "/",
+                "attributes": {"role": "admin"},
+            }],
+        )
+        assert len(resp.records) == 1
+        assert resp.records[0].shortname == "admin"
+
+    def test_failed_with_error(self):
+        resp = ApiResponse(
+            status=Status.failed,
+            error=Error(type="auth", code=401, message="nope"),
+        )
+        assert resp.status == Status.failed
+        assert resp.error.code == 401
+
+    def test_extra_fields_allowed(self):
+        resp = ApiResponse(status=Status.success, custom_field="hello")
+        assert resp.status == Status.success
+
+    def test_missing_status_raises(self):
+        with pytest.raises(ValidationError):
+            ApiResponse()
+
+
+# ---------------------------------------------------------------------------
+# Translation
+# ---------------------------------------------------------------------------
+class TestTranslation:
+    def test_all_none(self):
+        t = Translation()
+        assert t.en is None and t.ar is None and t.ku is None
+
+    def test_partial(self):
+        t = Translation(en="Hello", ar="\u0645\u0631\u062d\u0628\u0627")
+        assert t.en == "Hello"
+        assert t.ku is None
+
+
+# ---------------------------------------------------------------------------
+# LoginResponseRecord / ProfileResponseRecord
+# ---------------------------------------------------------------------------
+class TestLoginResponseRecord:
+    def test_inherits_api_record(self):
+        rec = LoginResponseRecord(
+            resource_type="user", shortname="u", subpath="/", attributes={"access_token": "tok"}
+        )
+        assert isinstance(rec, ApiResponseRecord)
+        assert rec.attributes["access_token"] == "tok"
+
+
+class TestProfileResponseRecord:
+    def test_inherits_api_record(self):
+        rec = ProfileResponseRecord(
+            resource_type="user", shortname="u", subpath="/", attributes={"roles": []}
+        )
+        assert isinstance(rec, ApiResponseRecord)
+
+
+# ---------------------------------------------------------------------------
+# Permission
+# ---------------------------------------------------------------------------
+class TestPermission:
+    def test_basic(self):
+        p = Permission(allowed_fields_values={"status": ["active"]})
+        assert p.allowed_actions == []
+        assert p.conditions == []
+        assert p.restricted_fields == []
+        assert p.allowed_fields_values == {"status": ["active"]}
+
+
+# ---------------------------------------------------------------------------
+# AggregationReducer / AggregationType
+# ---------------------------------------------------------------------------
+class TestAggregationReducer:
+    def test_basic(self):
+        r = AggregationReducer(name="count", alias="cnt")
+        assert r.name == "count"
+        assert r.args == []
+
+
+class TestAggregationType:
+    def test_with_reducer_objects(self):
+        agg = AggregationType(
+            load=["field1"],
+            group_by=["field2"],
+            reducers=[AggregationReducer(name="sum", alias="total", args=["amount"])],
+        )
+        assert len(agg.reducers) == 1
+
+    def test_with_string_reducers(self):
+        agg = AggregationType(reducers=["count", "sum"])
+        assert agg.reducers == ["count", "sum"]
+
+
+# ---------------------------------------------------------------------------
+# QueryRequest
+# ---------------------------------------------------------------------------
+class TestQueryRequest:
+    def test_minimal(self):
+        q = QueryRequest(type=QueryType.search, space_name="data", subpath="/", search="hello")
+        assert q.type == QueryType.search
+        assert q.limit == 10
+        assert q.offset == 0
+        assert q.sort_type == SortType.ascending
+
+    def test_full(self):
+        q = QueryRequest(
+            type=QueryType.aggregation,
+            space_name="data",
+            subpath="/reports",
+            search="*",
+            filter_types=[ResourceType.content],
+            filter_schema_names=["article"],
+            filter_shortnames=["doc1"],
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+            sort_by="created_at",
+            sort_type=SortType.descending,
+            retrieve_json_payload=True,
+            retrieve_attachments=True,
+            validate_schema=False,
+            jq_filter=".body",
+            exact_subpath=True,
+            limit=50,
+            offset=10,
+            aggregation_data=AggregationType(reducers=["count"]),
+        )
+        assert q.filter_types == [ResourceType.content]
+        assert q.limit == 50
+        assert q.aggregation_data is not None
+
+    def test_model_dump_roundtrip(self):
+        q = QueryRequest(type=QueryType.search, space_name="s", subpath="/", search="")
+        d = q.model_dump()
+        assert d["type"] == "search"
+        q2 = QueryRequest(**d)
+        assert q2 == q
+
+
+# ---------------------------------------------------------------------------
+# Payload
+# ---------------------------------------------------------------------------
+class TestPayload:
+    def test_basic(self):
+        p = Payload(content_type=ContentType.json, body={"key": "value"})
+        assert p.content_type == ContentType.json
+        assert p.body == {"key": "value"}
+
+    def test_string_body(self):
+        p = Payload(content_type=ContentType.text, body="plain text")
+        assert p.body == "plain text"
+
+
+# ---------------------------------------------------------------------------
+# MetaExtended
+# ---------------------------------------------------------------------------
+class TestMetaExtended:
+    def test_all_none_defaults(self):
+        m = MetaExtended()
+        assert m.email is None
+        assert m.msisdn is None
+        assert m.is_email_verified is None
+        assert m.state is None
+
+    def test_partial(self):
+        m = MetaExtended(email="a@b.com", state="active")
+        assert m.email == "a@b.com"
+        assert m.state == "active"
+
+
+# ---------------------------------------------------------------------------
+# ResponseEntry
+# ---------------------------------------------------------------------------
+class TestResponseEntry:
+    def test_minimal(self):
+        entry = ResponseEntry(uuid="u1", is_active=True, tags={"a", "b"})
+        assert entry.uuid == "u1"
+        assert entry.shortname is None
+        assert entry.subpath is None
+        assert entry.is_active is True
+        assert "a" in entry.tags
+
+    def test_full(self):
+        entry = ResponseEntry(
+            uuid="u1",
+            shortname="entry1",
+            subpath="/content",
+            is_active=False,
+            tags=set(),
+            displayname=Translation(en="Entry One"),
+            created_at="2024-01-01T00:00:00Z",
+            owner_shortname="admin",
+            email="a@b.com",
+            payload=Payload(content_type=ContentType.json, body={}),
+        )
+        assert entry.shortname == "entry1"
+        assert entry.displayname.en == "Entry One"
+        assert entry.payload.content_type == ContentType.json
+
+    def test_inherits_meta_extended(self):
+        assert issubclass(ResponseEntry, MetaExtended)
+
+
+# ---------------------------------------------------------------------------
+# ResponseRecord
+# ---------------------------------------------------------------------------
+class TestResponseRecord:
+    def test_basic(self):
+        rec = ResponseRecord(
+            resource_type=ResourceType.content,
+            uuid="u1",
+            shortname="doc",
+            subpath="/",
+            attributes={"status": "ok"},
+        )
+        assert rec.resource_type == ResourceType.content
+        assert rec.uuid == "u1"
+
+
+# ---------------------------------------------------------------------------
+# ActionResponse
+# ---------------------------------------------------------------------------
+class TestActionResponse:
+    def test_success_empty(self):
+        resp = ActionResponse(status=Status.success)
+        assert resp.records == []
+
+    def test_with_records(self):
+        resp = ActionResponse(
+            status=Status.success,
+            records=[{
+                "resource_type": "content",
+                "uuid": "u1",
+                "shortname": "doc",
+                "subpath": "/",
+                "attributes": {},
+            }],
+        )
+        assert len(resp.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# ActionRequestRecord
+# ---------------------------------------------------------------------------
+class TestActionRequestRecord:
+    def test_basic(self):
+        rec = ActionRequestRecord(
+            resource_type=ResourceType.content,
+            shortname="newdoc",
+            subpath="/docs",
+            attributes={"title": "New"},
+        )
+        assert rec.uuid is None
+        assert rec.attachments is None
+
+    def test_with_uuid(self):
+        rec = ActionRequestRecord(
+            resource_type=ResourceType.content,
+            uuid="u1",
+            shortname="doc",
+            subpath="/",
+            attributes={},
+        )
+        assert rec.uuid == "u1"
+
+
+# ---------------------------------------------------------------------------
+# ActionRequest
+# ---------------------------------------------------------------------------
+class TestActionRequest:
+    def test_basic(self):
+        req = ActionRequest(
+            space_name="myspace",
+            request_type=RequestType.create,
+        )
+        assert req.records == []
+
+    def test_with_records(self):
+        rec = ActionRequestRecord(
+            resource_type=ResourceType.content,
+            shortname="doc",
+            subpath="/",
+            attributes={},
+        )
+        req = ActionRequest(
+            space_name="myspace",
+            request_type=RequestType.create,
+            records=[rec],
+        )
+        assert len(req.records) == 1
+
+    def test_model_dump(self):
+        req = ActionRequest(
+            space_name="s",
+            request_type=RequestType.update,
+        )
+        d = req.model_dump()
+        assert d["space_name"] == "s"
+        assert d["request_type"] == "update"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,743 @@
+"""Tests for pydmart.service.DmartService.
+
+All HTTP calls are intercepted by aioresponses so no real network
+traffic is generated.
+"""
+
+import io
+import pytest
+import aiohttp
+from aioresponses import aioresponses
+
+from pydmart.service import DmartService
+from pydmart.models import (
+    ApiResponse,
+    DmartException,
+    QueryRequest,
+    ActionRequest,
+    ActionRequestRecord,
+    ResponseEntry,
+)
+from pydmart.enums import QueryType, ResourceType, RequestType, ContentType
+
+from helpers import (
+    BASE_URL,
+    make_success_response,
+    make_failed_response,
+    make_login_response,
+    make_profile_response,
+    make_entry_response,
+)
+
+
+# ---------------------------------------------------------------------------
+# Construction / lifecycle
+# ---------------------------------------------------------------------------
+class TestServiceInit:
+    def test_defaults(self):
+        svc = DmartService("http://localhost:8282")
+        assert svc.base_url == "http://localhost:8282"
+        assert svc.auth_token == ""
+        assert svc.current_user_roles == []
+        assert svc.current_user_permissions == []
+        assert svc._session is None
+
+    def test_instance_isolation(self):
+        """Mutable defaults must not be shared across instances."""
+        a = DmartService("http://a")
+        b = DmartService("http://b")
+        a.current_user_roles.append("admin")
+        assert b.current_user_roles == []
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self):
+        async with DmartService(BASE_URL) as svc:
+            assert svc._session is not None
+            assert not svc._session.closed
+        # after exit session should be closed
+        assert svc._session is None
+
+    @pytest.mark.asyncio
+    async def test_connect_close(self):
+        svc = DmartService(BASE_URL)
+        await svc.connect()
+        assert svc._session is not None
+        sess = svc._session
+        await svc.connect()  # idempotent
+        assert svc._session is sess
+        await svc.close()
+        assert svc._session is None
+
+    @pytest.mark.asyncio
+    async def test_close_when_not_connected(self):
+        svc = DmartService(BASE_URL)
+        await svc.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Headers
+# ---------------------------------------------------------------------------
+class TestHeaders:
+    def test_json_headers_no_token(self):
+        svc = DmartService(BASE_URL)
+        h = svc.json_headers
+        assert h["Content-Type"] == "application/json"
+        assert h["Authorization"] == ""
+
+    def test_json_headers_with_token(self):
+        svc = DmartService(BASE_URL)
+        svc.auth_token = "tok123"
+        assert svc.json_headers["Authorization"] == "Bearer tok123"
+
+    def test_headers_no_token(self):
+        svc = DmartService(BASE_URL)
+        assert svc.headers["Authorization"] == ""
+
+    def test_headers_with_token(self):
+        svc = DmartService(BASE_URL)
+        svc.auth_token = "tok123"
+        assert svc.headers["Authorization"] == "Bearer tok123"
+
+
+# ---------------------------------------------------------------------------
+# _request (low-level)
+# ---------------------------------------------------------------------------
+class TestRequest:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(f"{BASE_URL}/test", payload=make_success_response())
+                resp = await svc._request("GET", f"{BASE_URL}/test")
+                assert isinstance(resp, ApiResponse)
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_failed_status_raises(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(f"{BASE_URL}/test", payload=make_failed_response())
+                with pytest.raises(DmartException) as exc_info:
+                    await svc._request("GET", f"{BASE_URL}/test")
+                assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_raises(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                # Missing 'status' key triggers the inner except
+                m.get(f"{BASE_URL}/test", payload={"unexpected": True})
+                with pytest.raises(DmartException) as exc_info:
+                    await svc._request("GET", f"{BASE_URL}/test")
+                assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_client_error_raises(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(f"{BASE_URL}/test", exception=aiohttp.ClientError("conn refused"))
+                with pytest.raises(DmartException) as exc_info:
+                    await svc._request("GET", f"{BASE_URL}/test")
+                assert exc_info.value.status_code == 500
+                assert "conn refused" in exc_info.value.error.message
+
+
+# ---------------------------------------------------------------------------
+# Login / Auth
+# ---------------------------------------------------------------------------
+class TestLogin:
+    @pytest.mark.asyncio
+    async def test_login_success_stores_token(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/login", payload=make_login_response("my_token"))
+                resp = await svc.login("admin", "pass")
+                assert svc.auth_token == "my_token"
+                assert isinstance(resp, ApiResponse)
+
+    @pytest.mark.asyncio
+    async def test_login_no_records_raises(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/login", payload=make_success_response(records=[]))
+                with pytest.raises(DmartException) as exc_info:
+                    await svc.login("admin", "pass")
+                assert "no records" in exc_info.value.error.message
+
+    @pytest.mark.asyncio
+    async def test_login_failed_raises(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/login", payload=make_failed_response(message="bad creds"))
+                with pytest.raises(DmartException):
+                    await svc.login("admin", "wrong")
+
+    @pytest.mark.asyncio
+    async def test_login_empty_attributes_no_crash(self):
+        """Login record with no access_token should not crash."""
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                payload = make_success_response(records=[{
+                    "resource_type": "user",
+                    "shortname": "u",
+                    "subpath": "/",
+                    "attributes": {},
+                }])
+                m.post(f"{BASE_URL}/user/login", payload=payload)
+                await svc.login("u", "p")
+                assert svc.auth_token == ""
+
+
+class TestLoginBy:
+    @pytest.mark.asyncio
+    async def test_login_by_stores_token(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/login", payload=make_login_response("by_tok"))
+                resp = await svc.login_by({"email": "a@b.com"}, "pass")
+                assert svc.auth_token == "by_tok"
+                assert isinstance(resp, ApiResponse)
+
+    @pytest.mark.asyncio
+    async def test_login_by_no_records(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/login", payload=make_success_response())
+                resp = await svc.login_by({"email": "a@b.com"}, "pass")
+                assert svc.auth_token == ""  # unchanged
+
+
+class TestLogout:
+    @pytest.mark.asyncio
+    async def test_logout(self):
+        async with DmartService(BASE_URL) as svc:
+            svc.auth_token = "tok"
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/logout", payload=make_success_response())
+                resp = await svc.logout()
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# User management
+# ---------------------------------------------------------------------------
+class TestUserManagement:
+    @pytest.mark.asyncio
+    async def test_create_user(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/create", payload=make_success_response())
+                resp = await svc.create_user({"shortname": "new"})
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_update_user(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/profile", payload=make_success_response())
+                resp = await svc.update_user({"displayname": "New Name"})
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_check_existing(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(f"{BASE_URL}/user/check-existing?email=a@b.com", payload=make_success_response())
+                resp = await svc.check_existing("email", "a@b.com")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_user_reset(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/reset", payload=make_success_response())
+                resp = await svc.user_reset("baduser")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_validate_password(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/validate_password", payload=make_success_response())
+                resp = await svc.validate_password("Str0ng!Pass")
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# Profile
+# ---------------------------------------------------------------------------
+class TestGetProfile:
+    @pytest.mark.asyncio
+    async def test_caches_roles_and_permissions(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(f"{BASE_URL}/user/profile", payload=make_profile_response(
+                    roles=["editor"], permissions=["read"],
+                ))
+                resp = await svc.get_profile()
+                assert svc.current_user_roles == ["editor"]
+                assert svc.current_user_permissions == ["read"]
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_failed_profile_does_not_cache(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(f"{BASE_URL}/user/profile", payload=make_failed_response())
+                with pytest.raises(DmartException):
+                    await svc.get_profile()
+                assert svc.current_user_roles == []
+                assert svc.current_user_permissions == []
+
+
+# ---------------------------------------------------------------------------
+# Query / CSV / Spaces / Children
+# ---------------------------------------------------------------------------
+class TestQuery:
+    @pytest.mark.asyncio
+    async def test_query_managed(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/query", payload=make_success_response())
+                q = QueryRequest(type=QueryType.search, space_name="s", subpath="/", search="")
+                resp = await svc.query(q)
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_query_public_scope(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/public/query", payload=make_success_response())
+                q = QueryRequest(type=QueryType.search, space_name="s", subpath="/", search="")
+                resp = await svc.query(q, scope="public")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_csv(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/csv", payload=make_success_response())
+                q = QueryRequest(type=QueryType.search, space_name="s", subpath="/", search="")
+                resp = await svc.csv(q)
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_get_spaces(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/query", payload=make_success_response())
+                resp = await svc.get_spaces()
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_get_children(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/query", payload=make_success_response())
+                resp = await svc.get_children("myspace", "/docs", limit=5, offset=0)
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_get_children_with_types(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/query", payload=make_success_response())
+                resp = await svc.get_children(
+                    "myspace", "/", restrict_types=[ResourceType.content, ResourceType.folder],
+                )
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# Space / Request (actions)
+# ---------------------------------------------------------------------------
+class TestActions:
+    def _make_action(self) -> ActionRequest:
+        return ActionRequest(
+            space_name="myspace",
+            request_type=RequestType.create,
+            records=[ActionRequestRecord(
+                resource_type=ResourceType.content,
+                shortname="doc",
+                subpath="/",
+                attributes={"title": "New"},
+            )],
+        )
+
+    @pytest.mark.asyncio
+    async def test_space(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/space", payload=make_success_response())
+                resp = await svc.space(self._make_action())
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_request(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/request", payload=make_success_response())
+                resp = await svc.request(self._make_action())
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# retrieve_entry
+# ---------------------------------------------------------------------------
+class TestRetrieveEntry:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        url = f"{BASE_URL}/managed/entry/content/myspace/docs/doc1?retrieve_json_payload=False&retrieve_attachments=False&validate_schema=True"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(url, payload=make_entry_response())
+                entry = await svc.retrieve_entry(
+                    ResourceType.content, "myspace", "docs", "doc1",
+                )
+                assert isinstance(entry, ResponseEntry)
+                assert entry.uuid == "abc-123"
+                assert entry.shortname == "myentry"
+
+    @pytest.mark.asyncio
+    async def test_with_options(self):
+        url = f"{BASE_URL}/public/entry/folder/sp/sub/sn?retrieve_json_payload=True&retrieve_attachments=True&validate_schema=False"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(url, payload=make_entry_response())
+                entry = await svc.retrieve_entry(
+                    ResourceType.folder, "sp", "sub", "sn",
+                    retrieve_json_payload=True,
+                    retrieve_attachments=True,
+                    validate_schema=False,
+                    scope="public",
+                )
+                assert isinstance(entry, ResponseEntry)
+
+    @pytest.mark.asyncio
+    async def test_failed_raises(self):
+        url = f"{BASE_URL}/managed/entry/content/s/p/n?retrieve_json_payload=False&retrieve_attachments=False&validate_schema=True"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(url, payload=make_failed_response())
+                with pytest.raises(DmartException):
+                    await svc.retrieve_entry(ResourceType.content, "s", "p", "n")
+
+    @pytest.mark.asyncio
+    async def test_client_error_raises(self):
+        url = f"{BASE_URL}/managed/entry/content/s/p/n?retrieve_json_payload=False&retrieve_attachments=False&validate_schema=True"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(url, exception=aiohttp.ClientError("timeout"))
+                with pytest.raises(DmartException) as exc_info:
+                    await svc.retrieve_entry(ResourceType.content, "s", "p", "n")
+                assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# upload_with_payload
+# ---------------------------------------------------------------------------
+class TestUploadWithPayload:
+    @pytest.mark.asyncio
+    async def test_basic_upload(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/resource_with_payload", payload=make_success_response())
+                fake_file = io.BytesIO(b"file content")
+                resp = await svc.upload_with_payload(
+                    space_name="myspace",
+                    subpath="/uploads",
+                    shortname="file1",
+                    resource_type=ResourceType.media,
+                    payload_file=fake_file,
+                )
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_upload_with_content_type_and_schema(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/resource_with_payload", payload=make_success_response())
+                resp = await svc.upload_with_payload(
+                    space_name="s",
+                    subpath="/",
+                    shortname="f",
+                    resource_type=ResourceType.json,
+                    payload_file=io.BytesIO(b"{}"),
+                    content_type=ContentType.json,
+                    schema_shortname="myschema",
+                )
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# fetch_data_asset
+# ---------------------------------------------------------------------------
+class TestFetchDataAsset:
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/data-asset", payload=make_success_response())
+                resp = await svc.fetch_data_asset(
+                    resource_type="csv",
+                    data_asset_type="csv",
+                    space_name="data",
+                    subpath="/assets",
+                    shortname="sales",
+                )
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_with_options(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/managed/data-asset", payload=make_success_response())
+                resp = await svc.fetch_data_asset(
+                    resource_type="parquet",
+                    data_asset_type="parquet",
+                    space_name="data",
+                    subpath="/",
+                    shortname="ds",
+                    query_string="SELECT name FROM file",
+                    filter_data_assets=["col1"],
+                    branch_name="dev",
+                )
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# get_attachment_url (sync, no HTTP)
+# ---------------------------------------------------------------------------
+class TestGetAttachmentUrl:
+    def test_basic(self):
+        svc = DmartService(BASE_URL)
+        url = svc.get_attachment_url(
+            ResourceType.media, "sp", "sub", "parent", "child",
+        )
+        assert url == f"{BASE_URL}/managed/payload/media/sp/sub/parent/child"
+
+    def test_with_ext(self):
+        svc = DmartService(BASE_URL)
+        url = svc.get_attachment_url(
+            ResourceType.media, "sp", "sub", "parent", "child", ext=".png",
+        )
+        assert url.endswith("/child.png")
+
+    def test_custom_scope(self):
+        svc = DmartService(BASE_URL)
+        url = svc.get_attachment_url(
+            ResourceType.media, "sp", "sub", "p", "c", scope="public",
+        )
+        assert "/public/payload/" in url
+
+
+# ---------------------------------------------------------------------------
+# get_space_health / get_payload
+# ---------------------------------------------------------------------------
+class TestMiscEndpoints:
+    @pytest.mark.asyncio
+    async def test_get_space_health(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(f"{BASE_URL}/managed/health/myspace", payload=make_success_response())
+                resp = await svc.get_space_health("myspace")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_get_payload(self):
+        url = f"{BASE_URL}/managed/payload/content/sp/sub/doc.json"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(url, payload=make_success_response())
+                resp = await svc.get_payload("content", "sp", "sub", "doc")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_get_payload_with_schema(self):
+        url = f"{BASE_URL}/managed/payload/content/sp/sub/doc_article.json"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(url, payload=make_success_response())
+                resp = await svc.get_payload("content", "sp", "sub", "doc", schema_shortname="_article")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_get_manifest(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(f"{BASE_URL}/info/manifest", payload=make_success_response())
+                resp = await svc.get_manifest()
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_get_settings(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.get(f"{BASE_URL}/info/settings", payload=make_success_response())
+                resp = await svc.get_settings()
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# progress_ticket
+# ---------------------------------------------------------------------------
+class TestProgressTicket:
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        url = f"{BASE_URL}/managed/progress-ticket/sp/sub/t1/approve"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.put(url, payload=make_success_response())
+                resp = await svc.progress_ticket("sp", "sub", "t1", "approve")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_with_resolution_and_comment(self):
+        url = f"{BASE_URL}/managed/progress-ticket/sp/sub/t1/resolve"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.put(url, payload=make_success_response())
+                resp = await svc.progress_ticket(
+                    "sp", "sub", "t1", "resolve",
+                    resolution="fixed", comment="done",
+                )
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# submit
+# ---------------------------------------------------------------------------
+class TestSubmit:
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        url = f"{BASE_URL}/public/submit/sp/article/sub"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(url, payload=make_success_response())
+                resp = await svc.submit("sp", "article", "sub", {"title": "hi"})
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_with_resource_type(self):
+        url = f"{BASE_URL}/public/submit/sp/content/article/sub"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(url, payload=make_success_response())
+                resp = await svc.submit(
+                    "sp", "article", "sub", {"title": "hi"},
+                    resource_type=ResourceType.content,
+                )
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_with_workflow(self):
+        url = f"{BASE_URL}/public/submit/sp/content/review/article/sub"
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(url, payload=make_success_response())
+                resp = await svc.submit(
+                    "sp", "article", "sub", {},
+                    resource_type=ResourceType.content,
+                    workflow_shortname="review",
+                )
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# OTP / Password endpoints
+# ---------------------------------------------------------------------------
+class TestOtp:
+    @pytest.mark.asyncio
+    async def test_otp_request_msisdn(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/otp-request", payload=make_success_response())
+                resp = await svc.otp_request(msisdn="+123456789")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_otp_request_email(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/otp-request", payload=make_success_response())
+                resp = await svc.otp_request(email="a@b.com")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_otp_request_with_language(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/otp-request", payload=make_success_response())
+                resp = await svc.otp_request(email="a@b.com", accept_language="ar")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_otp_request_login(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/otp-request-login", payload=make_success_response())
+                resp = await svc.otp_request_login(msisdn="+123")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_otp_request_login_with_language(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/otp-request-login", payload=make_success_response())
+                resp = await svc.otp_request_login(email="x@y.com", accept_language="en")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_confirm_otp(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/otp-confirm", payload=make_success_response())
+                resp = await svc.confirm_otp("123456", msisdn="+123")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_confirm_otp_email(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/otp-confirm", payload=make_success_response())
+                resp = await svc.confirm_otp("654321", email="a@b.com")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_password_reset_request(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/password-reset-request", payload=make_success_response())
+                resp = await svc.password_reset_request(email="a@b.com")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_password_reset_request_msisdn(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/password-reset-request", payload=make_success_response())
+                resp = await svc.password_reset_request(msisdn="+111")
+                assert resp.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_password_reset_request_shortname(self):
+        async with DmartService(BASE_URL) as svc:
+            with aioresponses() as m:
+                m.post(f"{BASE_URL}/user/password-reset-request", payload=make_success_response())
+                resp = await svc.password_reset_request(shortname="user1")
+                assert resp.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# Lazy session creation via _get_session
+# ---------------------------------------------------------------------------
+class TestLazySession:
+    @pytest.mark.asyncio
+    async def test_request_creates_session_lazily(self):
+        svc = DmartService(BASE_URL)
+        assert svc._session is None
+        with aioresponses() as m:
+            m.get(f"{BASE_URL}/info/manifest", payload=make_success_response())
+            await svc.get_manifest()
+        assert svc._session is not None
+        await svc.close()


### PR DESCRIPTION
# Codebase Analysis & Fixes Report

## Issues Identified and Resolved

### `src/pydmart/service.py` — Major rewrite (7 fixes)

| # | Bug/Issue | Fix |
|---|---|---|
| 1 | **`get_settings` outside class** (was at module level, `self` undefined) | Moved into `DmartService` with proper indentation |
| 2 | **`login` logic error** — `not "records" in data and len(...)` had wrong operator precedence, would KeyError or never trigger | Rewrote to `not data.records or len(data.records) == 0` using the pydantic model attributes |
| 3 | **`login_by` treated `ApiResponse` as dict** — `data["records"][0]["attributes"]` on a pydantic model | Changed to `data.records[0].attributes.get("access_token", "")` |
| 4 | **Class-level mutable defaults** — `current_user_roles = []` shared across all instances | Moved to `__init__` as instance attributes |
| 5 | **New `aiohttp.ClientSession` per request** — defeated connection pooling | Added session lifecycle: `connect()`, `close()`, `async with` context manager, and lazy `_get_session()` |
| 6 | **`login()` duplicated HTTP logic** — copy-pasted try/except/session from `_request()` | Refactored to call `_request()` internally, then extract token from the returned `ApiResponse` |
| 7 | **`space()` commented out** | Restored as a working method |

Also fixed: all return type annotations unified to `ApiResponse` (previously some said `Dict[str, Any]` or `ActionResponse`), `otp_request`/`otp_request_login` now copy `json_headers` dict before mutating to avoid side effects.

### `src/pydmart/models.py` — 1 fix

| # | Issue | Fix |
|---|---|---|
| 8 | `ResponseEntry.shortname` and `.subpath` typed as `str = None` (type error) | Changed to `Optional[str] = None` |

### `setup.cfg` — 2 fixes

| # | Issue | Fix |
|---|---|---|
| 9 | Missing `install_requires` — `pip install pydmart` wouldn't install aiohttp/pydantic | Added `install_requires = aiohttp>=3.8.0, pydantic>=2.0.0` and `python_requires >= 3.11` |
| 10 | Typo "isntance" | Fixed to "instance" |

### `pyproject.toml` — 1 fix

| # | Issue | Fix |
|---|---|---|
| 11 | `aiohttp` in `build-system.requires` (it's a runtime dep, not build dep) | Removed from build requires |

### `src/pydmart/__init__.py` — 1 improvement

| # | Issue | Fix |
|---|---|---|
| 12 | Empty file — users had to `from pydmart.service import DmartService` | Now re-exports all public API: `from pydmart import DmartService` works |